### PR TITLE
Improving the collapsed form for attributes.

### DIFF
--- a/src/Tweaks/CollapseMemberAttributes/CollapseAttributeTagger.cs
+++ b/src/Tweaks/CollapseMemberAttributes/CollapseAttributeTagger.cs
@@ -13,14 +13,17 @@ namespace Tweakster
     public class CollapseAttributeTagger : ITagger<IStructureTag>
     {
         private readonly ITextBuffer _buffer;
+        private readonly bool _isShortCollapsedForm;
+        private readonly string _shortCollapsedForm = "...";
         private List<Span> _spans = new List<Span>();
         private bool _isParsing;
 
         public event EventHandler<SnapshotSpanEventArgs> TagsChanged;
 
-        public CollapseAttributeTagger(ITextBuffer buffer)
+        public CollapseAttributeTagger(ITextBuffer buffer, bool isShortCollapsedForm)
         {
             _buffer = buffer;
+            _isShortCollapsedForm = isShortCollapsedForm;
             _buffer.ChangedHighPriority += OnBufferChanged;
             Parse(_buffer.CurrentSnapshot);
         }
@@ -62,7 +65,7 @@ namespace Tweakster
                 guideLineHorizontalAnchor: outline.Start,
                 type: PredefinedStructureTagTypes.Nonstructural,
                 isCollapsible: true,
-                collapsedForm: firstLineText,
+                collapsedForm: _isShortCollapsedForm ? _shortCollapsedForm : firstLineText,
                 collapsedHintForm: firstLineText,
                 isDefaultCollapsed: true
             );

--- a/src/Tweaks/CollapseMemberAttributes/CollapseAttributeTaggerProvider.cs
+++ b/src/Tweaks/CollapseMemberAttributes/CollapseAttributeTaggerProvider.cs
@@ -18,7 +18,7 @@ namespace Tweakster
                 return null;
             }
 
-            return buffer.Properties.GetOrCreateSingletonProperty(() => new CollapseAttributeTagger(buffer)) as ITagger<T>;
+            return buffer.Properties.GetOrCreateSingletonProperty(() => new CollapseAttributeTagger(buffer, Options.Instance.CollapseMemberAttributesShortForm)) as ITagger<T>;
         }
     }
 }

--- a/src/Tweaks/CollapseMemberAttributes/Options.cs
+++ b/src/Tweaks/CollapseMemberAttributes/Options.cs
@@ -5,8 +5,8 @@ namespace Tweakster
     internal partial class Options : BaseOptionModel<Options>
     {
         [Category(Category.Editor)]
-        [DisplayName("Format on move line")]
-        [Description("Calls 'Format Selection' when a line is moved up or down using Alt+UP/DOWN shortcuts.")]
+        [DisplayName("Enable collapsing attributes")]
+        [Description("It provides the possibility to collapse group of attributes into one collapsed line.")]
         [DefaultValue(true)]
         public bool CollapseMemberAttributes { get; set; } = true;
     }

--- a/src/Tweaks/CollapseMemberAttributes/Options.cs
+++ b/src/Tweaks/CollapseMemberAttributes/Options.cs
@@ -9,5 +9,11 @@ namespace Tweakster
         [Description("It provides the possibility to collapse group of attributes into one collapsed line.")]
         [DefaultValue(true)]
         public bool CollapseMemberAttributes { get; set; } = true;
+
+        [Category(Category.Editor)]
+        [DisplayName("Short form for attribute collapse")]
+        [Description("Display short text (...) for the collapased form of attributes.")]
+        [DefaultValue(true)]
+        public bool CollapseMemberAttributesShortForm { get; set; } = true;
     }
 }


### PR DESCRIPTION
New option `CollapseMemberAttributesShortForm` is created. Based on its value, the collapsed form for the attributes will be "..." or the firstLine.

Notes:
- I had no other way to pass the option, except passing it to the constructor. VS restart will be required on value change from the settings.
- Display and description for the options might need to be revised. My description might not be the best :)