### PR TITLE
Enable collapsing of single attributes.

### DIFF
--- a/src/Tweaks/CollapseMemberAttributes/CollapseAttributeTagger.cs
+++ b/src/Tweaks/CollapseMemberAttributes/CollapseAttributeTagger.cs
@@ -105,7 +105,7 @@ namespace Tweakster
                         }
                         else
                         {
-                            if (start > 0 && numberOfLines > 1)
+                            if (start > 0 && (numberOfLines > 1 || (numberOfLines > 0 && _isShortCollapsedForm)))
                             {
                                 list.Add(Span.FromBounds(start, end));
                             }


### PR DESCRIPTION
Currently, if a member has only one attribute, then it's not collapsible (which is logical).
This PR changes that behaviour as follows:
- If `CollapseMemberAttributesShortForm` option is not enabled, the behaviour remains same.
- If `CollapseMemberAttributesShortForm` option is enabled, then even single attributes are collapsed to short form.

Currently:
![image](https://user-images.githubusercontent.com/24314310/88477927-65bf8f00-cf44-11ea-9916-efb51052000d.png)

Update:
![image](https://user-images.githubusercontent.com/24314310/88477928-6bb57000-cf44-11ea-9054-314fe3c89f93.png)
