### PR TITLE
Fix `CopyWithoutIndentation` handling to much

### DIFF
--- a/src/Tweaks/Editor/CopyWithoutIndentation.cs
+++ b/src/Tweaks/Editor/CopyWithoutIndentation.cs
@@ -28,7 +28,7 @@ namespace Tweakster.Tweaks.Editor
             ITextSelection selection = args.TextView.Selection;
 
             // Only handle single selections
-            if (selection.SelectedSpans.Count < 1 || !Options.Instance.CopyWithoutIndentation)
+            if (selection.SelectedSpans.Count != 1 || !Options.Instance.CopyWithoutIndentation)
             {
                 return false;
             }

--- a/src/Tweaks/Editor/CopyWithoutIndentation.cs
+++ b/src/Tweaks/Editor/CopyWithoutIndentation.cs
@@ -27,8 +27,9 @@ namespace Tweakster.Tweaks.Editor
         {
             ITextSelection selection = args.TextView.Selection;
 
-            // Only handle single selections
-            if (selection.SelectedSpans.Count != 1 || !Options.Instance.CopyWithoutIndentation)
+            if (selection.SelectedSpans.Count != 1 // Only handle single selections
+                || selection.Start.Position == selection.End.Position // Don't handle zero-width selections
+                || !Options.Instance.CopyWithoutIndentation)
             {
                 return false;
             }


### PR DESCRIPTION
`CopyWithoutIndentation` didn't properly skip selections with multiple spans.

It also didn't skip zero-width selections which prevented quick duplication of a line by pressing [Ctrl]+[C], [V] without selecting anything (related to #46).