### PR TITLE
Add a tweak to activate the Build Order tab on build completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It's from those tickets inspiration for this extension came.
   * [Delete obj and bin folders on *Clean*](#deleteoutputartifacts)
   * [Show build time statistics](#buildstats)
   * [Up-To-Date Check Verbose](#u2dcheckverbosity)
+  * [Show ordered build output after build](#showBuildOrdered)
 * **Debugger**
   * [Don't start debug on F10/F11](#nodebugonf10)
   * [Toggle *Just My Code* from the *Debug* toolbar](#justmycode)
@@ -175,6 +176,10 @@ can help easily diagnose why a project is being rebuilt. Setting the build *Outp
 generated when this setting is enabled goes directly to the *Output Window*, even with *Minimal* build output verbosity.
 
 ![Up To Date Check](art/up-to-date-check.png)
+
+<h4 id="showBuildOrdered">Show ordered build output</h4>
+
+Activates the Build Order pane in the Output Window when the build completes.
 
 ### Debugger
 

--- a/src/Tweaks/Build/BuildOrdered.cs
+++ b/src/Tweaks/Build/BuildOrdered.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using EnvDTE;
+using EnvDTE80;
+using Microsoft;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
+
+namespace Tweakster
+{
+    public class BuildOrdered
+    {
+        private static BuildEvents _buildEvents;
+
+        public static async Task InitializeAsync(AsyncPackage package)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(package.DisposalToken);
+
+            IVsOutputWindow outWindow = await package.GetServiceAsync<SVsOutputWindow, IVsOutputWindow>();
+            Assumes.Present(outWindow);
+
+            outWindow.GetPane(VSConstants.OutputWindowPaneGuid.SortedBuildOutputPane_guid, out IVsOutputWindowPane buildPane);
+
+            DTE2 dte = await package.GetServiceAsync<DTE, DTE2>();
+            Assumes.Present(dte);
+
+            _buildEvents = dte.Events.BuildEvents;
+            _buildEvents.OnBuildDone += (s, a) => OnBuildDone(a, buildPane);
+        }
+
+        private static void OnBuildDone(vsBuildAction action, IVsOutputWindowPane buildPane)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (Options.Instance.ShowBuildOrder)
+            {
+                buildPane.Activate();
+            }
+        }
+    }
+}

--- a/src/Tweaks/Build/Options.cs
+++ b/src/Tweaks/Build/Options.cs
@@ -34,5 +34,11 @@ namespace Tweakster
         [OverrideCollectionName("General")]
         [OverrideDataType(SettingDataType.Bool)]
         public bool U2DCheckVerbosity { get; set; } = false;
+
+        [Category(_build)]
+        [DisplayName("Show ordered build output")]
+        [Description("Activate the Build Order tab in the Output Window after each build")]
+        [DefaultValue(false)]
+        public bool ShowBuildOrder { get; set; } = false;
     }
 }

--- a/src/Tweakster.csproj
+++ b/src/Tweakster.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Common\SVsSettingsPersistenceManager.cs" />
     <Compile Include="Options\OverrideCollectionNameAttribute.cs" />
     <Compile Include="Options\OverrideDataTypeAttribute.cs" />
+    <Compile Include="Tweaks\Build\BuildOrdered.cs" />
     <Compile Include="Tweaks\Editor\CopyWithoutIndentation.cs" />
     <Compile Include="Tweaks\Editor\SelectWholeLineCommand.cs" />
     <Compile Include="Tweaks\Editor\WarnOnPaste.cs" />

--- a/src/TweaksterPackage.cs
+++ b/src/TweaksterPackage.cs
@@ -33,6 +33,7 @@ namespace Tweakster
             await ResetZoomLevel.InitializeAsync(this);
             await JustMyCode.InitializeAsync(this);
             await BuildStats.InitializeAsync(this);
+            await BuildOrdered.InitializeAsync(this);
             await FindInSolutionExplorer.InitializeAsync(this);
             await OpenLanguageSettings.InitializeAsync(this);
             await CloseActiveDocument.InitializeAsync(this);


### PR DESCRIPTION
A small tweak to automatically switch the output window to the "Build Order" tab when a build completes.
Useful for finding the source of errors after a parallel build of multiple projects.

Very similar code to the Build Stats tweak.