### PR TITLE
Add installer to jump list

### DIFF
--- a/src/TweaksterShared/Tweaks/Ide/Options.cs
+++ b/src/TweaksterShared/Tweaks/Ide/Options.cs
@@ -16,5 +16,11 @@ namespace Tweakster
         [Description("Determines if Safe Mode should be added to the Windows Jump List. Requires Visual Studio restart.")]
         [DefaultValue(true)]
         public bool EnableSafeMode { get; set; } = true;
+
+        [Category(_general)]
+        [DisplayName("Enable Visual Studio Installer Shortcut")]
+        [Description("Determines if a shortcut to launch the Visual Studio Installer should be added to the Windows Jump List. Requires Visual Studio restart.")]
+        [DefaultValue(true)]
+        public bool EnableInstallerShortcut { get; set; } = true;
     }
 }

--- a/src/TweaksterShared/Tweaks/Ide/WindowsJumpLists.cs
+++ b/src/TweaksterShared/Tweaks/Ide/WindowsJumpLists.cs
@@ -44,7 +44,7 @@ namespace Tweakster.Tweaks.General
                 ApplicationPath = _installerPath,
                 IconResourcePath = _installerPath,
                 Title = "Visual Studio Installer",
-                Description = "Starts Visual Studio installer.",
+                Description = "Starts the Visual Studio installer.",
                 Arguments = ""
             };
 

--- a/src/TweaksterShared/Tweaks/Ide/WindowsJumpLists.cs
+++ b/src/TweaksterShared/Tweaks/Ide/WindowsJumpLists.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Shell;
 
@@ -6,21 +7,24 @@ namespace Tweakster.Tweaks.General
 {
     public class WindowsJumpLists
     {
-        public static void Initialize()
+        private static string _devenvPath;
+        private static string _installerPath;
+        public static void Initialize(string DevEnvPath, string InstallerPath)
         {
             Options.Saved += delegate { AddJumpListItems(); };
+
+            _devenvPath = DevEnvPath;
+            _installerPath = InstallerPath;
 
             AddJumpListItems();
         }
 
         private static void AddJumpListItems()
         {
-            var devenv = Process.GetCurrentProcess().MainModule.FileName;
-
             var presentationMode = new JumpTask
             {
-                ApplicationPath = devenv,
-                IconResourcePath = devenv,
+                ApplicationPath = _devenvPath,
+                IconResourcePath = _devenvPath,
                 Title = "Presentation Mode",
                 Description = "Starts a separate Visual Studio instance with its own settings, layout, extensions, and more...",
                 Arguments = "/RootSuffix Demo"
@@ -28,11 +32,20 @@ namespace Tweakster.Tweaks.General
 
             var safeMode = new JumpTask
             {
-                ApplicationPath = devenv,
-                IconResourcePath = devenv,
+                ApplicationPath = _devenvPath,
+                IconResourcePath = _devenvPath,
                 Title = "Safe Mode",
                 Description = "Starts Visual Studio in limited functionality mode where all extensions are disabled.",
                 Arguments = "/SafeMode"
+            };
+
+            var installerShortcut = new JumpTask
+            {
+                ApplicationPath = _installerPath,
+                IconResourcePath = _installerPath,
+                Title = "Visual Studio Installer",
+                Description = "Starts Visual Studio installer.",
+                Arguments = ""
             };
 
             JumpList list = JumpList.GetJumpList(Application.Current) ?? new JumpList();
@@ -46,6 +59,11 @@ namespace Tweakster.Tweaks.General
             if (Options.Instance.EnableSafeMode)
             {
                 list.JumpItems.Add(safeMode);
+            }
+
+            if(Options.Instance.EnableInstallerShortcut)
+            {
+                list.JumpItems.Add(installerShortcut);
             }
 
             list.Apply();

--- a/src/TweaksterShared/TweaksterPackage.cs
+++ b/src/TweaksterShared/TweaksterPackage.cs
@@ -1,8 +1,12 @@
 ﻿using System;
+using System.Diagnostics;
+using System.IO.Packaging;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Tweakster.Tweaks.General;
 using Task = System.Threading.Tasks.Task;
 
@@ -21,7 +25,13 @@ namespace Tweakster
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-            WindowsJumpLists.Initialize();
+            IVsSetupCompositionService setupCompositionService = await this.GetServiceAsync(typeof(SVsSetupCompositionService)) as IVsSetupCompositionService;
+            Assumes.Present(setupCompositionService);
+
+            var devenvPath = Process.GetCurrentProcess().MainModule.FileName;;
+            var installerPath = setupCompositionService.InstallerPath;
+
+            WindowsJumpLists.Initialize(devenvPath, installerPath);
 
             await NoStepDebuggingInDesignMode.InitializeAsync(this);
             await Restart.InitializeAsync(this);


### PR DESCRIPTION
Adding a JumpList task item to launch the Visual Studio installer along with a tool option to enable/disable it.

The installer path is discovered from Microsoft.VisualStudio.Shell.Interop.IVSSetupCompositionService.InstallerPath

![image](https://user-images.githubusercontent.com/10997361/200946845-2e6b2d2c-40f4-4d01-893e-4621be3e0a01.png)
