### PR TITLE
Arm64 extension support

### DIFF
--- a/src/Tweaks2019/Tweakster2019.csproj
+++ b/src/Tweaks2019/Tweakster2019.csproj
@@ -99,7 +99,7 @@
       <Version>16.9.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.1.4054</Version>
+      <Version>17.4.2119</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Tweaks2022/Tweakster2022.csproj
+++ b/src/Tweaks2022/Tweakster2022.csproj
@@ -97,7 +97,7 @@
       <Version>2.3.2262-g94fae01e</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.1.4054</Version>
+      <Version>17.4.2119</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Tweaks2022/source.extension.vsixmanifest
+++ b/src/Tweaks2022/source.extension.vsixmanifest
@@ -14,6 +14,9 @@
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+      <ProductArchitecture>arm64</ProductArchitecture>
+    </InstallationTarget>
   </Installation>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
Adds support for running on Visual Studio 2022 17.4+ Arm64. 

![Screenshot_20221115_123217](https://user-images.githubusercontent.com/4016293/201834857-205837df-874f-42fa-b408-4ed85e1728e3.png)
![Screenshot_20221115_123253](https://user-images.githubusercontent.com/4016293/201834908-31a9ef6d-e97e-4041-8bf4-5b333f9dfa77.png)
![Screenshot_20221115_123308](https://user-images.githubusercontent.com/4016293/201834945-8dbd58de-e34a-4906-89ec-1d91ec05b361.png)
![Screenshot_20221115_123139](https://user-images.githubusercontent.com/4016293/201835074-a30b9b52-a5d0-424c-a6cd-c3b19c9bac8f.png)

