### PR TITLE
Add ability to collapse XML comments to short/compact collapsed form.

### DIFF
--- a/src/Tweaks2022/Tweakster2022.csproj
+++ b/src/Tweaks2022/Tweakster2022.csproj
@@ -87,17 +87,17 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Community.VisualStudio.Toolkit.17" ExcludeAssets="Runtime">
-      <Version>17.0.394</Version>
+      <Version>17.0.527</Version>
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Framework">
-      <Version>16.10.0</Version>
+      <Version>17.11.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop">
-      <Version>2.3.2262-g94fae01e</Version>
+      <Version>3.11.2177</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.4.2119</Version>
+      <Version>17.11.435</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/TweaksterShared/Tweaks/Editor/CollapseTagger.cs
+++ b/src/TweaksterShared/Tweaks/Editor/CollapseTagger.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Adornments;
+using Microsoft.VisualStudio.Text.Tagging;
+using Task = System.Threading.Tasks.Task;
+
+namespace Tweakster
+{
+    public abstract class CollapseTagger : ITagger<IStructureTag>
+    {
+        private readonly ITextBuffer _buffer;
+        private readonly bool _isShortCollapsedForm;
+        private readonly string _shortCollapsedForm;
+        private List<Span> _spans = new List<Span>();
+        private bool _isParsing;
+
+        public event EventHandler<SnapshotSpanEventArgs> TagsChanged;
+
+        public CollapseTagger(ITextBuffer buffer, bool isShortCollapsedForm, string shortCollapsedForm)
+        {
+            _buffer = buffer;
+            _isShortCollapsedForm = isShortCollapsedForm;
+            _shortCollapsedForm = shortCollapsedForm;
+            _buffer.ChangedHighPriority += OnBufferChanged;
+            Parse(_buffer.CurrentSnapshot);
+        }
+
+        private delegate bool ShouldCollapseDelegate(ITextSnapshotLine line, out Span span);
+        protected abstract bool ShouldCollapse(ITextSnapshotLine line, out Span span);
+
+        private void OnBufferChanged(object sender, TextContentChangedEventArgs e)
+        {
+            if (e.After == _buffer.CurrentSnapshot)
+            {
+                Parse(_buffer.CurrentSnapshot);
+            }
+        }
+
+        public IEnumerable<ITagSpan<IStructureTag>> GetTags(NormalizedSnapshotSpanCollection spans)
+        {
+            foreach (SnapshotSpan span in spans)
+            {
+                IEnumerable<Span> outlines = _spans.Where(s => s.IntersectsWith(span));
+
+                foreach (Span outline in outlines.Where(o => _buffer.CurrentSnapshot.Length >= o.End))
+                {
+                    var snapshotSpan = new SnapshotSpan(_buffer.CurrentSnapshot, outline);
+                    StructureTag tag = CreateTag(outline);
+
+                    yield return new TagSpan<IStructureTag>(snapshotSpan, tag);
+                }
+            }
+        }
+
+        private StructureTag CreateTag(Span outline)
+        {
+            ITextSnapshotLine line = _buffer.CurrentSnapshot.GetLineFromPosition(outline.Start);
+            var firstLineText = line.GetText().Trim();
+
+            return new StructureTag(
+                _buffer.CurrentSnapshot,
+                outliningSpan: outline,
+                headerSpan: line.Extent,
+                guideLineSpan: outline,
+                guideLineHorizontalAnchor: outline.Start,
+                type: PredefinedStructureTagTypes.Nonstructural,
+                isCollapsible: true,
+                collapsedForm: _isShortCollapsedForm ? _shortCollapsedForm : firstLineText,
+                collapsedHintForm: firstLineText,
+                isDefaultCollapsed: true
+            );
+        }
+
+        private void Parse(ITextSnapshot snapshot)
+        {
+            if (_isParsing)
+            {
+                return;
+            }
+
+            _isParsing = true;
+            var typeName = GetType().Name;
+
+            // Create a closure to avoid referencing the instance in the background thread.
+            ShouldCollapseDelegate shouldCollapse = ShouldCollapse;
+
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await Task.Delay(200);
+
+                var list = new List<Span>();
+                var start = 0;
+                var end = 0;
+                var numberOfLines = 0;
+
+                try
+                {
+                    foreach (ITextSnapshotLine line in snapshot.Lines)
+                    {
+                        if (shouldCollapse(line, out Span span))
+                        {
+                            if (start == 0)
+                            {
+                                start = span.Start;
+                            }
+
+                            end = span.End;
+                            numberOfLines++;
+                        }
+                        else
+                        {
+                            if (start > 0 && (numberOfLines > 1 || (numberOfLines > 0 && _isShortCollapsedForm)))
+                            {
+                                list.Add(Span.FromBounds(start, end));
+                            }
+
+                            numberOfLines = 0;
+                            start = 0;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    await ex.LogAsync();
+                }
+
+                _spans = list;
+                _isParsing = false;
+                var args = new SnapshotSpanEventArgs(new SnapshotSpan(snapshot, 0, snapshot.Length));
+
+                TagsChanged?.Invoke(this, args);
+
+            }).FileAndForget(typeName);
+        }
+    }
+}

--- a/src/TweaksterShared/Tweaks/Editor/CollapseXmlCommentTagger.cs
+++ b/src/TweaksterShared/Tweaks/Editor/CollapseXmlCommentTagger.cs
@@ -2,13 +2,13 @@
 
 namespace Tweakster
 {
-    public class CollapseAttributeTagger : CollapseTagger
+    public class CollapseXmlCommentTagger : CollapseTagger
     {
-        private const string _shortCollapsedForm = "...";
+        private const string _shortCollapsedForm = "///";
 
-        public CollapseAttributeTagger(ITextBuffer buffer, bool isShortCollapsedForm)
+        public CollapseXmlCommentTagger(ITextBuffer buffer, bool isShortCollapsedForm)
             : base(buffer, isShortCollapsedForm, _shortCollapsedForm)
-        { 
+        {
         }
 
         protected override bool ShouldCollapse(ITextSnapshotLine line, out Span span)
@@ -20,7 +20,7 @@ namespace Tweakster
 
             clean = clean.TrimEnd();
 
-            return !string.IsNullOrEmpty(clean) && clean.StartsWith("[") && clean.EndsWith("]");
+            return !string.IsNullOrEmpty(clean) && clean.StartsWith("///");
         }
     }
 }

--- a/src/TweaksterShared/Tweaks/Editor/CollapseXmlCommentTaggerProvider.cs
+++ b/src/TweaksterShared/Tweaks/Editor/CollapseXmlCommentTaggerProvider.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Tagging;
+using Microsoft.VisualStudio.Utilities;
+using Community.VisualStudio.Toolkit;
+
+namespace Tweakster
+{
+    [Export(typeof(ITaggerProvider))]
+    [TagType(typeof(IStructureTag))]
+    [Name(nameof(CollapseXmlCommentTaggerProvider))]
+    [ContentType(ContentTypes.CSharp)]
+    internal sealed class CollapseXmlCommentTaggerProvider : ITaggerProvider
+    {
+        public ITagger<T> CreateTagger<T>(ITextBuffer buffer) where T : ITag
+        {
+            if (!Options.Instance.CollapseXmlComments)
+            {
+                return null;
+            }
+
+            return buffer.Properties.GetOrCreateSingletonProperty(() => new CollapseXmlCommentTagger(buffer, Options.Instance.CollapseXmlCommentsShortForm)) as ITagger<T>;
+        }
+    }
+}

--- a/src/TweaksterShared/Tweaks/Editor/Options.cs
+++ b/src/TweaksterShared/Tweaks/Editor/Options.cs
@@ -32,6 +32,18 @@ namespace Tweakster
         public bool CollapseMemberAttributesShortForm { get; set; } = true;
 
         [Category(_editor)]
+        [DisplayName("Enable collapsing XML comments")]
+        [Description("It provides the possibility to collapse XML comments into one collapsed line.")]
+        [DefaultValue(true)]
+        public bool CollapseXmlComments { get; set; } = true;
+
+        [Category(_editor)]
+        [DisplayName("Short form for XML comment collapse")]
+        [Description("Display short text (///) for the collapsed form of XML comments.")]
+        [DefaultValue(true)]
+        public bool CollapseXmlCommentsShortForm { get; set; } = true;
+
+        [Category(_editor)]
         [DisplayName("Enable mouse wheel zoom")]
         [Description("Enable zooming in the editor when hitting Ctrl+MouseScroll")]
         [DefaultValue(false)]

--- a/src/TweaksterShared/TweaksterShared.projitems
+++ b/src/TweaksterShared/TweaksterShared.projitems
@@ -23,6 +23,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Tweaks\Debugger\NoStepDebuggingInDesignMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tweaks\Debugger\Options.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tweaks\Editor\CodeCleanupOnFormat.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tweaks\Editor\CollapseXmlCommentTaggerProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tweaks\Editor\CollapseXmlCommentTagger.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tweaks\Editor\CollapseTagger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tweaks\Editor\CollapseAttributeTagger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tweaks\Editor\CollapseAttributeTaggerProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tweaks\Editor\CopyWithoutIndentation.cs" />


### PR DESCRIPTION
Fixes #126 

I reused the same infrastructure of the attribute collapse tagger. Changes include:
- Added common abstract collapse tagger
- Added CollapseXmlCommentTagger
- Refactored the CollapseAttributeTagger.
- Some of the NuGet dependencies were no longer available, so all NuGet packages for Tweakster2022 are updated to the latest versions. Tweakster2019 is left as is.

PS. There are also version conflicts, binding redirects might need to be added. Not added as part of this PR.